### PR TITLE
Make serde support optional; remove unused bitvec dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qfilter"
-version = "0.1.2"
+version = "0.1.3"
 description = "Approximate Membership Query Filter (AMQ-Filter) based on the Rank Select Quotient Filter (RSQF)"
 repository = "https://github.com/arthurprs/qfilter"
 authors = ["Arthur Silva <arthurprs@gmail.com>"]
@@ -15,12 +15,12 @@ exclude = ["fuzz", "benches"]
 default = []
 # Enable to support running on x64 cpus released before 2008
 legacy_x86_64_support = []
+serde = ["dep:serde", "dep:serde_bytes"]
 
 [dependencies]
-bitvec = "1"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
-serde = { version = "1", features = ["derive"] }
-serde_bytes = "0.11"
+serde = { optional = true, version = "1", features = ["derive"] }
+serde_bytes = { optional = true, version = "0.11" }
 
 [dev-dependencies]
 serde_cbor = "0.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,23 +74,28 @@ use std::{
     ops::{RangeBounds, RangeFrom},
 };
 
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use stable_hasher::StableHasher;
 
 mod stable_hasher;
 
 /// Approximate Membership Query Filter (AMQ-Filter) based on the Rank Select Quotient Filter (RSQF).
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Filter {
-    #[serde(rename = "b", with = "serde_bytes")]
+    #[cfg_attr(feature = "serde", serde(rename = "b", with = "serde_bytes"))]
     buffer: Vec<u8>,
-    #[serde(rename = "l")]
+    #[cfg_attr(feature = "serde", serde(rename = "l"))]
     len: u64,
-    #[serde(rename = "q")]
+    #[cfg_attr(feature = "serde", serde(rename = "q"))]
     qbits: NonZeroU8,
-    #[serde(rename = "r")]
+    #[cfg_attr(feature = "serde", serde(rename = "r"))]
     rbits: NonZeroU8,
-    #[serde(rename = "g", skip_serializing_if = "Option::is_none", default)]
+    #[cfg_attr(
+        feature = "serde",
+        serde(rename = "g", skip_serializing_if = "Option::is_none", default)
+    )]
     max_qbits: Option<NonZeroU8>,
 }
 
@@ -1570,6 +1575,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_serde() {
         for capacity in [100, 1000, 10000] {


### PR DESCRIPTION
Make `serde` support optional via feature flags and remove the unused `bitvec` dependency.