### PR TITLE
 Detect overflow when calculating the number of slots; Improve constructor doc strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qfilter"
-version = "0.1.3"
+version = "0.1.4"
 description = "Approximate Membership Query Filter (AMQ-Filter) based on the Rank Select Quotient Filter (RSQF)"
 repository = "https://github.com/arthurprs/qfilter"
 authors = ["Arthur Silva <arthurprs@gmail.com>"]


### PR DESCRIPTION
* Detect overflow when calculating the number of slots
* Improve constructor doc strings

A subsequent version should add fallible constructors, but that requires augmenting the Error enum, which is a breaking change.

Closes #2 