### PR TITLE
Optionally support schemars JsonSchema

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,14 @@ exclude = ["fuzz", "benches"]
 default = []
 # Enable to support running on x64 cpus released before 2008
 legacy_x86_64_support = []
+jsonschema = ["schemars"]
 serde = ["dep:serde", "dep:serde_bytes"]
 
 [dependencies]
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 serde = { optional = true, version = "1", features = ["derive"] }
 serde_bytes = { optional = true, version = "0.11" }
+schemars = { optional = true, version = "0.8" }
 
 [dev-dependencies]
 serde_cbor = "0.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,8 @@ use std::{
     ops::{RangeBounds, RangeFrom},
 };
 
+#[cfg(feature = "jsonschema")]
+use schemars::JsonSchema;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use stable_hasher::StableHasher;
@@ -83,8 +85,16 @@ mod stable_hasher;
 /// Approximate Membership Query Filter (AMQ-Filter) based on the Rank Select Quotient Filter (RSQF).
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "jsonschema", derive(JsonSchema))]
 pub struct Filter {
-    #[cfg_attr(feature = "serde", serde(rename = "b", with = "serde_bytes"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            rename = "b",
+            serialize_with = "serde_bytes::serialize",
+            deserialize_with = "serde_bytes::deserialize"
+        )
+    )]
     buffer: Vec<u8>,
     #[cfg_attr(feature = "serde", serde(rename = "l"))]
     len: u64,


### PR DESCRIPTION
At brainhive we build web APIs which rely on `JsonSchema` for generating API specifications. With this PR users can opt-in by using the `jsonschema` feature. If you don't want to support/maintain this feel free to close this PR!